### PR TITLE
Fix memory issue when using Python2

### DIFF
--- a/kaldiio/highlevel.py
+++ b/kaldiio/highlevel.py
@@ -123,7 +123,8 @@ class ReadHelper(object):
             if self.segments is not None:
                 it = self.dict.generator()
             else:
-                it = iter(self.dict.items())
+                # Don't use items() for python2-compatibility
+                it = ((k, self.dict[k]) for k in self.dict)
 
             while True:
                 try:


### PR DESCRIPTION
What: Memory issue occurs when using `kaldiio.ReadHelper` with large `scp` file.

Condition:
```
python==2
```

Repro:

```python
import kaldiio

with kaldiio.ReadHelper('scp:feats.scp') as f:
    for k, a in f:
        pass
```

Why: I invoked  `collections.MutableMapping.items()` method but it is not a generator function in Python2, thus all matrices are loaded.