### PR TITLE
Fix writing matrices to stdout

### DIFF
--- a/kaldiio/utils.py
+++ b/kaldiio/utils.py
@@ -150,10 +150,10 @@ class _stdstream_wrap(object):
         pass
 
     def __getattr__(self, name):
-        return getattr(self._stream, name)
+        return getattr(self.fd, name)
 
     def __iter__(self):
-        return iter(self._stream)
+        return iter(self.fd)
 
 
 def open_like_kaldi(name, mode='r'):


### PR DESCRIPTION
Small fix for when passing `'ark:-'` to the `WriteHelper`
Before it would get a RecursionError, since it doesn't have the attribute `_stream`. You can test it with this example from the Readme:
```python
import numpy
from kaldiio import WriteHelper
with WriteHelper('ark:-') as writer:
    for i in range(10):
        writer(str(i), numpy.random.randn(10, 10))
```